### PR TITLE
Fix reactions

### DIFF
--- a/miceco.py
+++ b/miceco.py
@@ -278,7 +278,9 @@ if getReactions:
                 "userId": userid,
                 "sinceDate": seit,
                 "untilDate": lastTimestamp
-            })
+                }, headers={
+                    "Authorization": f"Bearer {token}"
+                })
             req.raise_for_status()
         except requests.exceptions.HTTPError as err:
             print("Couldn't get Posts! " + str(err))


### PR DESCRIPTION
This will allow users to get reactions in case they set their reactions to be non-public
The authorisation is - as far as I know - not documented, but works